### PR TITLE
update from rinvex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](CONTRIBUTING.md).
 
 
+## [v7.3.2] - 2024-07-22
+- Upgrade vinkla/hashids to v12 (#85)
+- Fix rules override (#84)
+
 ## [v7.3.1] - 2023-08-30
 - Support new accessarea file-based structure
 
@@ -323,6 +327,7 @@ This project adheres to [Semantic Versioning](CONTRIBUTING.md).
 ## v0.0.1 - 2016-12-20
 - Tag first release
 
+[v7.3.2]: https://github.com/rinvex/laravel-support/compare/v7.3.1...v7.3.2
 [v7.3.1]: https://github.com/rinvex/laravel-support/compare/v7.3.0...v7.3.1
 [v7.3.0]: https://github.com/rinvex/laravel-support/compare/v7.2.6...v7.3.0
 [v7.2.6]: https://github.com/rinvex/laravel-support/compare/v7.2.5...v7.2.6

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
         "spatie/laravel-sluggable": "^3.4.0",
         "spatie/laravel-schemaless-attributes": "^2.4.0",
         "spatie/laravel-translatable": "^6.0.0",
-        "vinkla/hashids": "^11.0.0",
+        "vinkla/hashids": "^11.0.0 || ^12.0.0",
         "watson/validating": "^8.0.0"
     },
     "require-dev": {

--- a/src/Traits/HashidsTrait.php
+++ b/src/Traits/HashidsTrait.php
@@ -58,7 +58,7 @@ trait HashidsTrait
      */
     protected function shouldBeHashed(): bool
     {
-        $accessareas = app('accessareas')->active()->obscured()->keys()->when($this->obscure, fn($collection) => $collection->merge(collect($this->obscure)->intersect(app('accessareas')->active()->keys()))->unique())->toArray();
+        $accessareas = app('accessareas')->active()->obscured()->keys()->when($this->obscure, fn ($collection) => $collection->merge(collect($this->obscure)->intersect(app('accessareas')->active()->keys()))->unique())->toArray();
 
         return in_array(request()->accessarea(), $accessareas) && in_array($this->getRouteKeyName(), config('cortex.foundation.obscure.hashed_keys'));
     }

--- a/src/Traits/ValidatingTrait.php
+++ b/src/Traits/ValidatingTrait.php
@@ -21,7 +21,7 @@ trait ValidatingTrait
      */
     public function mergeRules(array $rules)
     {
-        $this->rules += $rules;
+        $this->rules = array_merge($this->rules, $rules);
 
         return $this;
     }


### PR DESCRIPTION
This pull request updates dependencies and fixes a bug in rule merging. The most important changes are the upgrade of the `vinkla/hashids` package to support v12, and a correction to how validation rules are merged to prevent override issues.

Dependency updates:

* Updated the `vinkla/hashids` dependency in `composer.json` to support both v11 and v12, allowing compatibility with newer versions.

Bug fixes:

* Fixed the `mergeRules` method in `ValidatingTrait` (`src/Traits/ValidatingTrait.php`) to use `array_merge` instead of the `+=` operator, ensuring rules are properly merged and overrides work as expected.

Documentation:

* Added a new changelog entry for version `v7.3.2` in `CHANGELOG.md`, documenting the upgrade and bug fix.
* Added a comparison link for `v7.3.2` in the changelog for easier navigation between versions.